### PR TITLE
Consequently importing QtQuick version 2.5 instead of mixing 2.5 and 2.7

### DIFF
--- a/qtodotxt2/qml/AboutBox.qml
+++ b/qtodotxt2/qml/AboutBox.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.5
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
 

--- a/qtodotxt2/qml/MainMenu.qml
+++ b/qtodotxt2/qml/MainMenu.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.5
 import QtQuick.Controls 1.4
 import QtQml 2.2
 

--- a/qtodotxt2/qml/Preferences.qml
+++ b/qtodotxt2/qml/Preferences.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.5
 import QtQuick.Dialogs 1.2
 import QtQuick.Controls 1.4
 import Qt.labs.settings 1.0

--- a/qtodotxt2/qml/TaskLine.qml
+++ b/qtodotxt2/qml/TaskLine.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.5
 import QtQuick.Controls 1.4
 
 import Theme 1.0

--- a/qtodotxt2/qml/TaskListTableView.qml
+++ b/qtodotxt2/qml/TaskListTableView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.5
 import QtQuick.Dialogs 1.1
 import QtQuick.Controls 1.4
 

--- a/qtodotxt2/qml/TaskListView.qml
+++ b/qtodotxt2/qml/TaskListView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.5
 import QtQuick.Controls 1.4
 
 ListView {


### PR DESCRIPTION
Does it work on your platforms?
Should I do this for the other branches too?