### PR TITLE
make the hyperlinks in aboutbox actually work

### DIFF
--- a/qtodotxt2/qml/AboutBox.qml
+++ b/qtodotxt2/qml/AboutBox.qml
@@ -38,7 +38,13 @@ GNU General Public License for more details.</p>
 along with this program.  If not, see
 <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>.</p>
 '
+        onLinkActivated: Qt.openUrlExternally(link)
 
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.NoButton
+            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+        }
     }
     standardButtons: StandardButton.Ok
     onVisibleChanged: if (visible === false) destroy()


### PR DESCRIPTION
The hyperlinks in the aboutbox didn't work, so I fixed them:
- open a browser when the hyperlinks are clicked
- change the pointer icon to a hand when hovering on hyperlinks