### PR TITLE
Allow auto-reloading, defaulting to off. (#100)

### DIFF
--- a/qtodotxt2/main_controller.py
+++ b/qtodotxt2/main_controller.py
@@ -273,6 +273,10 @@ class MainController(QtCore.QObject):
             self._file = File()
             self._loadFileToUI()
 
+    @QtCore.pyqtSlot(result='bool')
+    def canAutoReload(self):
+        return bool(self._settings.value("Preferences/auto_reload", False, type=bool))
+
     @QtCore.pyqtSlot()
     def reload(self):
         self.open(self._file.filename)

--- a/qtodotxt2/qml/Preferences.qml
+++ b/qtodotxt2/qml/Preferences.qml
@@ -8,6 +8,7 @@ Dialog {
     Settings {
         category: "Preferences"
         property alias auto_save: autoSaveCB.checked
+        property alias auto_reload: autoReloadCB.checked
         property alias singleton: singletonCB.checked
         property alias lowest_priority: lowestPriorityField.text
         property alias add_creation_date: creationDateCB.checked
@@ -24,6 +25,11 @@ Dialog {
                 id: autoSaveCB
                 text: qsTr("Autosave") 
                 checked: true
+            }
+            CheckBox {
+                id: autoReloadCB
+                text: qsTr("Auto-reload")
+                checked: false
             }
             CheckBox {
                 id:creationDateCB

--- a/qtodotxt2/qml/QTodoTxt.qml
+++ b/qtodotxt2/qml/QTodoTxt.qml
@@ -16,6 +16,23 @@ ApplicationWindow {
     height: 768
     title: mainController.title
 
+    Timer {
+        id: timer
+    }
+
+    // Adapted from:
+    // https://stackoverflow.com/questions/28507619/how-to-create-delay-function-in-qml
+    function delay(delayTime, cb) {
+        timer.interval = delayTime;
+        timer.repeat = false;
+        timer.triggered.connect(cb);
+        timer.triggered.connect(function release () {
+            timer.triggered.disconnect(cb);
+            timer.triggered.disconnect(release);
+        });
+        timer.start();
+    }
+
     Connections {
         target: mainController
         onError: {
@@ -24,7 +41,9 @@ ApplicationWindow {
         }
         onFileExternallyModified: {
             if ( mainController.canAutoReload() ) {
-                mainController.reload()
+                delay(1000, function() {
+                    mainController.reload()
+                })
             } else {
                 reloadDialog.open()
             }

--- a/qtodotxt2/qml/QTodoTxt.qml
+++ b/qtodotxt2/qml/QTodoTxt.qml
@@ -23,7 +23,11 @@ ApplicationWindow {
             errorDialog.open()
         }
         onFileExternallyModified: {
-            reloadDialog.open()
+            if ( mainController.canAutoReload() ) {
+                mainController.reload()
+            } else {
+                reloadDialog.open()
+            }
         }
         onFiltersUpdated: {
             filtersTree.expandAll()


### PR DESCRIPTION
This patch creates a new setting that causes QTodoTxt2 to auto-reload todo.txt on changes, rather than ask whether to reload.  By default, the setting is off, thus preserving current behavior.
