### PR TITLE
Add support Japanese(which has no spaces between words) on filtering.

### DIFF
--- a/qtodotxt2/lib/filters.py
+++ b/qtodotxt2/lib/filters.py
@@ -1,4 +1,5 @@
 import re
+from PyQt5 import QtCore
 from datetime import date, datetime, timedelta
 
 
@@ -366,7 +367,10 @@ class SimpleTextFilter(BaseFilter):
 
         # Return a pattern that will match the beginning of a word or not,
         # anywhere in the string, without consuming any of the string.
-        return r'^(?' + ('!' if negate else '=') + r'.*' + beginning + term + r')'
+        if QtCore.QSettings().value("Preferences/match_only_beginnings_of_words_when_filtering", True, type=bool):
+            return r'^(?' + ('!' if negate else '=') + r'.*' + beginning + term + r')'
+        else:
+            return r'^(?' + ('!' if negate else '=') + r'.*' + term + r')'
 
     @staticmethod
     def compile(searchString):

--- a/qtodotxt2/qml/Preferences.qml
+++ b/qtodotxt2/qml/Preferences.qml
@@ -12,6 +12,7 @@ Dialog {
         property alias singleton: singletonCB.checked
         property alias lowest_priority: lowestPriorityField.text
         property alias add_creation_date: creationDateCB.checked
+        property alias match_only_beginnings_of_words_when_filtering: matchOnlyBeginningsOfWordsWhenFilteringCB.checked
     }
     GroupBox {
         Column {
@@ -35,6 +36,11 @@ Dialog {
                 id:creationDateCB
                 text: qsTr("Add creation date")
                 checked: false
+            }
+            CheckBox {
+                id:matchOnlyBeginningsOfWordsWhenFilteringCB
+                text: qsTr("Match only beginnings of words when filtering")
+                checked: true
             }
             Row { 
                 Label {text: "Lowest task priority:"}

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -16,6 +16,7 @@ class Test(unittest.TestCase):
         QtCore.QCoreApplication.setOrganizationName("QTodoTxt")
         QtCore.QCoreApplication.setApplicationName("Testing")
         QtCore.QSettings().setValue("Preferences/auto_save", False)
+        QtCore.QSettings().setValue("Preferences/match_only_beginnings_of_words_when_filtering", True)
         cls.ctrl = MainController([])
         cls.ctrl.allTasks = cls.make_tasks()
         cls.ctrl.showCompleted = True
@@ -41,6 +42,8 @@ class Test(unittest.TestCase):
         t = tasklib.Task("x (B) Task due:{} +project2 @context3".format(tomorrow))
         tasks.append(t)
         t = tasklib.Task("(B) Task home +project2 @context3")
+        tasks.append(t)
+        t = tasklib.Task("りんごを購入する") # This sentence means "Buy an apple" in Japanese.
         tasks.append(t)
         return tasks
 
@@ -81,6 +84,22 @@ class Test(unittest.TestCase):
         self.assertEqual(len(self.ctrl.filteredTasks), 4)
         self.ctrl.searchText = "!due home"
         self.assertEqual(len(self.ctrl.filteredTasks), 1)
+        self.ctrl.searchText = "2015"
+        self.assertEqual(len(self.ctrl.filteredTasks), 2)
+        QtCore.QSettings().setValue("Preferences/match_only_beginnings_of_words_when_filtering", False)
+        self.ctrl.searchText = "購入"
+        self.assertEqual(len(self.ctrl.filteredTasks), 1)
+        self.ctrl.searchText = "home"
+        self.assertEqual(len(self.ctrl.filteredTasks), 2)
+        self.ctrl.searchText = "+project2"
+        self.assertEqual(len(self.ctrl.filteredTasks), 4)
+        self.ctrl.searchText = "!due home"
+        self.assertEqual(len(self.ctrl.filteredTasks), 1)
+        self.ctrl.searchText = "2015"
+        self.assertEqual(len(self.ctrl.filteredTasks), 2)
+        QtCore.QSettings().setValue("Preferences/match_only_beginnings_of_words_when_filtering", True)
+        self.ctrl.searchText = "購入"
+        self.assertEqual(len(self.ctrl.filteredTasks), 0)
         self.ctrl.searchText = ""
 
     def test_filter_or(self):


### PR DESCRIPTION
Hi,

I use QTodoTxt2, thank you.

But there are a problem.
I write todo.txt in Japanese, but Japanese has no spaces between words.
I feel strange that  behavior of filter.
Specifically, if I filtered by "購入"(means "buy" in Japanese), I hope it shows task "りんごを購入する"(means "Buy apples" in Japanese).
But the current software does not show it.

I changed the code, added some tests to make sure it passed, and actually ran it to make sure it was behaving the way I wanted it to.
It can enable or disable in the settings window.

Could you consider including support for languages which has no spaces between words?