### PR TITLE
fix recurrence for months, years, and multi-digit increments

### DIFF
--- a/qtodotxt2/lib/tasklib.py
+++ b/qtodotxt2/lib/tasklib.py
@@ -1,4 +1,6 @@
 from datetime import datetime, date, time, MAXYEAR, timedelta
+from dateutil.relativedelta import relativedelta
+
 import re
 from enum import Enum
 
@@ -391,9 +393,9 @@ def recurTask(task):
     elif task.recursion.interval == 'w':
         delta = timedelta(weeks=int(task.recursion.increment))
     elif task.recursion.interval == 'm':
-        delta = timedelta(weeks=int(task.recursion.increment) * 4)  # 4 weeks in a month
+        delta = relativedelta(months=int(task.recursion.increment))  # 1 month in a month, not 4 weeks
     elif task.recursion.interval == 'y':
-        delta = timedelta(weeks=int(task.recursion.increment) * 52)  # 52 weeks in a year
+        delta = relativedelta(years=int(task.recursion.increment))  # 1 year in a year, not 52 weeks
     else:
         # Test already made during line parsing - shouldn't be a problem here
         pass

--- a/qtodotxt2/lib/tasklib.py
+++ b/qtodotxt2/lib/tasklib.py
@@ -10,7 +10,7 @@ from qtodotxt2.lib.task_htmlizer import TaskHtmlizer
 
 
 class RecursiveMode(Enum):
-    completitionDate = 0  # Original due date mode: Task recurs from original due date
+    completionDate = 0  # Original due date mode: Task recurs from original due date
     originalDueDate = 1  # Completion date mode: Task recurs from completion date
 
 
@@ -226,7 +226,7 @@ class Task(QtCore.QObject):
         else:
             # Test if chracters have the right format
             if re.match('^[1-9][bdwmy]', word[4:6]):
-                self.recursion = Recursion(RecursiveMode.completitionDate, word[4], word[5])
+                self.recursion = Recursion(RecursiveMode.completionDate, word[4], word[5])
             else:
                 print("Error parsing recurrence '{}'".format(word))
     

--- a/qtodotxt2/lib/tasklib.py
+++ b/qtodotxt2/lib/tasklib.py
@@ -172,7 +172,7 @@ class Task(QtCore.QObject):
             self.text = self._text + ' h:1'
         else:
             txt = self._text.replace(' h:1', '')
-            self.text = txt.replace('h:1', '')  # also take the case whe h_1 is at the begynning
+            self.text = txt.replace('h:1', '')  # also take the case whe h_1 is at the beginning
 
     @QtCore.pyqtProperty('QString', notify=modified)
     def priority(self):
@@ -217,16 +217,18 @@ class Task(QtCore.QObject):
     def _parseRecurrence(self, word):
         # Original due date mode
         if word[4] == '+':
-            # Test if chracters have the right format
-            if re.match('^[1-9][bdwmy]', word[5:7]):
-                self.recursion = Recursion(RecursiveMode.originalDueDate, word[5], word[6])
+            # check correct format for strict recurrence (with the leading '+')
+            # allow 1 or more digits for increment
+            if re.match('^[1-9]+[bdwmy]', word[5:]):
+                # send all digits as increment and last char as interval
+                self.recursion = Recursion(RecursiveMode.originalDueDate, word[5:-1], word[-1])
             else:
                 print("Error parsing recurrence '{}'".format(word))
         # Completion mode
         else:
-            # Test if chracters have the right format
-            if re.match('^[1-9][bdwmy]', word[4:6]):
-                self.recursion = Recursion(RecursiveMode.completionDate, word[4], word[5])
+            # same as above for "normal recurrence" (without leading '+')
+            if re.match('^[1-9]+[bdwmy]', word[4:]):
+                self.recursion = Recursion(RecursiveMode.completionDate, word[4:-1], word[-1])
             else:
                 print("Error parsing recurrence '{}'".format(word))
     

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -200,7 +200,7 @@ class TestTasks(unittest.TestCase):
     def test_recurring_task_input_days(self):
         task = Task('(C) do something due:2016-09-05 rec:5d')
         self.assertIsNotNone(task.recursion)
-        self.assertTrue(task.recursion.mode == RecursiveMode.completitionDate)
+        self.assertTrue(task.recursion.mode == RecursiveMode.completionDate)
         self.assertTrue(task.recursion.increment == str(5))
         self.assertTrue(task.recursion.interval == 'd')
 
@@ -214,7 +214,7 @@ class TestTasks(unittest.TestCase):
     def test_recurring_task_input_months(self):
         task = Task('(C) do something due:2016-09-05 rec:3m')
         self.assertIsNotNone(task.recursion)
-        self.assertTrue(task.recursion.mode == RecursiveMode.completitionDate)
+        self.assertTrue(task.recursion.mode == RecursiveMode.completionDate)
         self.assertTrue(task.recursion.increment == str(3))
         self.assertTrue(task.recursion.interval == 'm')
 


### PR DESCRIPTION
Before: Recurrence periods in months `m` were re-calculated as weeks, which created an unexpected offset, e.g., 28 days instead of 1 months (which could have 30 or 31 days). As the number of months grows, the offset grows to a week or more. Recurrence periods in years `y` were recalculated as x years times 52 weeks, which created offsets as well.

Now: This is fixed, a month is a month and a year is a year, without using approximations in weeks.
